### PR TITLE
Add wavecast distribution tests and permission error handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,9 +40,17 @@ async def setup_hook(self) -> None:
 async def spin_wheel():
     print("Activating the V-Wheel!!")
     # need to iterate through the roles so that the previous winner can be dehoisted automatically
-    for role in bot.guilds[0].roles:
-        if role.name in const_types:
-            await role.edit(hoist=False)
+    try:
+        for role in bot.guilds[0].roles:
+            if role.name in const_types:
+                await role.edit(hoist=False)
+    except discord.Forbidden:
+        owner = bot.guilds[0].owner
+        await owner.send(
+            "Hey! I don't have permission to manage roles. "
+            "Please make sure my role is above the type roles in Server Settings > Roles!"
+        )
+        return
     await v_wheel_channel.send("https://i.imgur.com/3EZpMlF.gif")
     await v_wheel_channel.send("It's time to spin the V-Wheeeeeeeeeeeeeeeel!")
     vwheel_type = wavecast.cycle()  # spiiiiiinnnnnnn
@@ -51,7 +59,14 @@ async def spin_wheel():
     role = bot.guilds[0].get_role(role_id)  # format it as a Discord object so it can be manipulated
     if role is not None:
         print("Fetched the role ID successfully")
-        await role.edit(hoist=not role.hoist)  # inverts the current setting
+        try:
+            await role.edit(hoist=not role.hoist)  # inverts the current setting
+        except discord.Forbidden:
+            owner = bot.guilds[0].owner
+            await owner.send(
+                f"Hey! I couldn't hoist the {vwheel_type} role. "
+                "Please make sure my role is above the type roles in Server Settings > Roles!"
+            )
     else:
         print("Error fetching server roles, cannot hoist the V-Wheel winner")
     wavecast.save(wavecast_filepath)


### PR DESCRIPTION
## Summary
- Add pytest tests validating the bag system's type distribution over 365 simulated days (each type must appear 19-21 times across 100 random seeds)
- Handle `discord.Forbidden` errors during V-Wheel spins by DM'ing the server owner with instructions to fix the role hierarchy
- Uncomment `.python-version` in `.gitignore`

## Test plan
- [ ] Run `pytest test_wavecast.py -v` — all 15 tests should pass
- [ ] Verify bot still spins correctly in Discord with `/forcespin`
- [ ] Test permission error handling by placing the bot role below type roles and running `/forcespin` — server owner should receive a DM

🤖 Generated with [Claude Code](https://claude.com/claude-code)